### PR TITLE
FIX - Filtering out dumped entrylist files

### DIFF
--- a/results/views.py
+++ b/results/views.py
@@ -90,6 +90,7 @@ def resultSelect(request, instance):
     """ Show available results """
     results_path = os.path.join(DATA_DIR, 'instances', instance, 'results')
     files = sorted(glob.glob('%s/*.json'%(results_path)), reverse=True)
+    files = filter(lambda x: not x.endswith('entrylist.json') , files) 
 
     results = []
     for f in files:


### PR DESCRIPTION
Adding a filter to remove dumped "entrylist" files from results.

When the server has Dump Entry List options active, this file is dumped alongside the results of the races.

This file was crashing the Results table.