### PR TITLE
Allow the override of CSRF_TRUSTED_ORIGINS with an environment variable

### DIFF
--- a/accservermanager/settings.py
+++ b/accservermanager/settings.py
@@ -121,6 +121,9 @@ SECRET_KEY = os.environ['SECRET_KEY'] \
 ALLOWED_HOSTS = json.loads(os.environ['ALLOWED_HOSTS']) \
     if 'ALLOWED_HOSTS' in os.environ else []
 
+CSRF_TRUSTED_ORIGINS = json.loads(os.environ['CSRF_TRUSTED_ORIGINS']) \
+    if 'CSRF_TRUSTED_ORIGINS' in os.environ else []
+
 ALLOW_SAME_PORTS = True if os.getenv('ALLOW_SAME_PORTS','False').lower() == 'true' else False
 
 try:


### PR DESCRIPTION
When accservermanager is behind a reverse proxy, a recent Django update seems to require the `CSRF_TRUSTED_ORIGINS` option to be set in order to pass the csrf check on the login form.

This PR adds the ability to override it with an environment variable.