### PR TITLE
Improve Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM debian:11.5-slim
 
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y wine python3-pip && \
-    apt-get clean  && \
+    DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y wine python3-pip && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /accservermanager /data


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size.

Summary of Change:
* I added the `--no-install-recommends` to with apt-get in order to not install unnecessary packages and reduce the image size.


Impact on the image size:
* Image size before repair: 1.14 GB
* Image size after repair: 491.26 MB
* Difference: 680.38 MB (58.07%)

I hope that you will find these changes useful to you. :smile:
Let me know if you have any questions or concerns.

Thanks,